### PR TITLE
Support multiple paths in config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.swp
-/bin
+bin
 *.deb

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ GO_PACKAGES := $(shell go list ./... | sed 's_github.com/heroku/json2envdir_._')
 
 all: build
 
-build:
-	go install $(GO_BUILD_FLAGS) ./...
+build: ldflags
+	go build -o ./bin/json2envdir ${LDFLAGS} ./cmd/json2envdir/
 
 imports:
 	goimports -w $(GO_PACKAGES)
@@ -24,7 +24,6 @@ goimports:
 
 golint:
 	go get github.com/golang/lint/golint
-
 
 deb: tmp ldflags ver
 	echo "making deb"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Notice that you can have dynamic value for an env var. The format is in Go templ
 path = /www/webapp/env.d
 
 [envdir "myapp"]
-path = /etc/myapp/env.d
+path = /etc/myapp1/env.d
+path = /etc/myapp2/env.d
 file-perms = 0640
 path-perms = 0750
 ```

--- a/cmd/json2envdir/main.go
+++ b/cmd/json2envdir/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -13,6 +14,8 @@ import (
 var (
 	jsonFile   = flag.String("file", "-", "file with JSON environment")
 	configFile = flag.String("config", "", "config file")
+	versionFlag = flag.BoolP("version", "v", false, "show version")
+	version     = "dev"
 )
 
 func readStdin() string {
@@ -33,6 +36,11 @@ func readFile(filename string) string {
 
 func main() {
 	flag.Parse()
+
+	if *versionFlag {
+		fmt.Println(version)
+		return
+	}
 
 	cfg := config.LoadConfig(*configFile)
 

--- a/cmd/json2envdir/main.go
+++ b/cmd/json2envdir/main.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	jsonFile   = flag.String("file", "-", "file with JSON environment")
-	configFile = flag.String("config", "", "config file")
+	jsonFile    = flag.StringP("file", "f", "-", "file with JSON environment")
+	configFile  = flag.StringP("config", "c", config.DefaultConfigFile, "config file")
 	versionFlag = flag.BoolP("version", "v", false, "show version")
 	version     = "dev"
 )

--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,7 @@ type Config struct {
 }
 
 type EnvDirSection struct {
-	Path            string
+	Path            []string
 	PathPermsString string `gcfg:"path-perms"`
 	FilePermsString string `gcfg:"file-perms"`
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestLoadConfig(t *testing.T) {
+	cfgStr := `[envdir "myapp"]
+path = path1
+path = path2
+file-perms = 0640
+path-perms = 0750
+`
+
+	dir, err := ioutil.TempDir("", "config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "example.conf")
+	err = ioutil.WriteFile(path, []byte(cfgStr), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := LoadConfig(path)
+	section := cfg.Sections["myapp"]
+	if section == nil {
+		t.Fatalf("no myapp section is found")
+	}
+
+	if !reflect.DeepEqual(section.Path, []string{"path1", "path2"}) {
+		t.Fatalf("section should contain path1 and path2: %v", section.Path)
+	}
+
+	if section.PathPermsString != "0750" {
+		t.Fatalf("path perms should equal to 0750", section.PathPermsString)
+	}
+
+	if section.FilePermsString != "0640" {
+		t.Fatalf("file perms should equal to 0640", section.FilePermsString)
+	}
+}

--- a/json2envdir_test.go
+++ b/json2envdir_test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/heroku/json2envdir/config"
@@ -12,16 +11,22 @@ import (
 )
 
 func TestParse(t *testing.T) {
-	dir, err := ioutil.TempDir("", "json2envdir")
+	dir1, err := ioutil.TempDir("", "json2envdir1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(dir)
+	defer os.RemoveAll(dir1)
+
+	dir2, err := ioutil.TempDir("", "json2envdir2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir2)
 
 	cfg := config.Config{
 		Sections: map[string]*config.EnvDirSection{
 			"myapp": &config.EnvDirSection{
-				Path: dir,
+				Path: []string{dir1, dir2},
 			},
 		},
 	}
@@ -29,31 +34,48 @@ func TestParse(t *testing.T) {
 		"name": "myapp",
 		"env": {
 			"MYVAR": "123",
-			"MYVAR_TMPL": "{{.UUID}} 123"
+			"MYVAR_TMPL": "{{.UUID}}"
 		}
 	}`)
 	if err != nil {
 		t.Fatalf("Unexpected error in Parse: %s", err)
 	}
 
-	b, err := ioutil.ReadFile(filepath.Join(dir, "MYVAR"))
+	b, err := ioutil.ReadFile(filepath.Join(dir1, "MYVAR"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(b) != "123" {
-		t.Fatalf("Value of $MYVAR should equal to 123, but it's %s", b)
+		t.Fatalf("Value of $MYVAR in dir1 should equal to 123, but it's %s", b)
 	}
 
-	b, err = ioutil.ReadFile(filepath.Join(dir, "MYVAR_TMPL"))
+	b, err = ioutil.ReadFile(filepath.Join(dir1, "MYVAR_TMPL"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	parts := strings.Split(string(b), " ")
-	_, err = uuid.FromString(parts[0])
+	uuid1, err := uuid.FromString(string(b))
 	if err != nil {
-		t.Fatalf("Value of $MYVAR_TMPL should contain a UUID")
+		t.Fatalf("Value of $MYVAR_TMPL in dir1 should contain a UUID")
 	}
-	if parts[1] != "123" {
-		t.Fatalf("Value of $MYVAR_TMPL should contain 123, but it's %s", b)
+
+	b, err = ioutil.ReadFile(filepath.Join(dir2, "MYVAR"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "123" {
+		t.Fatalf("Value of $MYVAR in dir2 should equal to 123, but it's %s", b)
+	}
+
+	b, err = ioutil.ReadFile(filepath.Join(dir2, "MYVAR_TMPL"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	uuid2, err := uuid.FromString(string(b))
+	if err != nil {
+		t.Fatalf("Value of $MYVAR_TMPL in dir2 should contain a UUID")
+	}
+
+	if uuid1 != uuid2 {
+		t.Fatalf("uuid1 should equal to uuid2: uuid1=%s uuid2=%s", uuid1, uuid2)
 	}
 }


### PR DESCRIPTION
For example,

```
[envdir "myapp"]
path = /etc/myapp1/env.d
path = /etc/myapp2/env.d
file-perms = 0640
path-perms = 0750
```