### PR TITLE
fix: Don't panic on unknown names.

### DIFF
--- a/cmd/json2envdir/main.go
+++ b/cmd/json2envdir/main.go
@@ -46,9 +46,9 @@ func main() {
 
 	var err error
 	if *jsonFile == "-" {
-		err = json2envdir.Parse(cfg, readStdin())
+		err = json2envdir.Process(cfg, readStdin())
 	} else {
-		err = json2envdir.Parse(cfg, readFile(*jsonFile))
+		err = json2envdir.Process(cfg, readFile(*jsonFile))
 	}
 
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -40,12 +40,13 @@ func LoadConfig(configFile string) Config {
 	return cfg
 }
 
-func (cfg Config) GetEnv(env string) EnvDirSection {
+func (cfg Config) GetEnv(env string) (EnvDirSection, error) {
 	if conf, ok := cfg.Sections[env]; ok {
 		conf.ParsePerms()
-		return *conf
+		return *conf, nil
 	}
-	panic(fmt.Sprintf("envdir '%s' not found in config", env))
+
+	return EnvDirSection{}, fmt.Errorf("envdir '%s' not found in config", env)
 }
 
 func ParsePerms(perms string, def os.FileMode) os.FileMode {

--- a/json2envdir.go
+++ b/json2envdir.go
@@ -13,7 +13,7 @@ import (
 	"github.com/satori/go.uuid"
 )
 
-type JSON struct {
+type payload struct {
 	Name string                 `json:"name"`
 	Env  map[string]interface{} `json:"env"`
 }
@@ -23,22 +23,30 @@ type JSON struct {
 type Funcs struct {
 }
 
+// UUID is a function exposed to the templates for generating a UUIDv4
 func (f Funcs) UUID() string {
 	u := uuid.NewV4()
 	return u.String()
 }
 
-func Parse(cfg config.Config, rawJSON string) error {
-	var j JSON
-	err := json.Unmarshal([]byte(rawJSON), &j)
+// Process parses and populates the envdirs specified in the config if matching
+// data is found in the json payload.
+func Process(cfg config.Config, rawJSON string) error {
+	var p payload
+	err := json.Unmarshal([]byte(rawJSON), &p)
 	if err != nil {
 		return err
 	}
 
-	envCfg := cfg.GetEnv(j.Name)
+	envCfg, err := cfg.GetEnv(p.Name)
+	if err != nil {
+		fmt.Printf("Skipping unconfigured entry: %s", p.Name)
+		return nil
+	}
+
 	funcs := Funcs{}
-	for key := range j.Env {
-		value := fmt.Sprintf("%v", j.Env[key])
+	for key := range p.Env {
+		value := fmt.Sprintf("%v", p.Env[key])
 
 		var result bytes.Buffer
 		tmpl, err := template.New("").Parse(value)

--- a/json2envdir_test.go
+++ b/json2envdir_test.go
@@ -10,6 +10,33 @@ import (
 	"github.com/satori/go.uuid"
 )
 
+func TestParseNoConfig(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "json2envdirTest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(testDir) }()
+
+	cfg := config.Config{
+		Sections: map[string]*config.EnvDirSection{
+			"cheetah": &config.EnvDirSection{
+				Path: []string{testDir},
+			},
+		},
+	}
+
+	err = Process(cfg, `{
+		"name": "not-cheetah",
+		"env": {
+			"VAR": "{{.UUID}}"
+		}
+	}`)
+
+	if err != nil {
+		t.Fatalf("Unexpected failure: %q", err)
+	}
+}
+
 func TestParse(t *testing.T) {
 	dir1, err := ioutil.TempDir("", "json2envdir1")
 	if err != nil {
@@ -30,7 +57,7 @@ func TestParse(t *testing.T) {
 			},
 		},
 	}
-	err = Parse(cfg, `{
+	err = Process(cfg, `{
 		"name": "myapp",
 		"env": {
 			"MYVAR": "123",


### PR DESCRIPTION
Prior to this, if json2envdir received a JSON payload that contained
a "name" that was not present in the config it would panic. Now it will
emit a message and skip.

- Also changed a few names. 
- Added some documentation.