### PR TITLE
Add hex template function for improved password formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ In goes json, out goes envdir.
   "env": {
     "MYVAR": "123",
     "MYVAR_TMPL": "{{.UUID}} 123",
+    "MYVAR_HEX": "{{.HEX 32}} 123",
     ...
   }
 }
 ```
 
-Notice that you can have dynamic value for an env var. The format is in Go template. Currently only `{{.UUID}}` is supported.
+Notice that you can have dynamic value for an env var. The format is in Go template. Currently `{{.UUID}}` and `{{.HEX N}}` are supported. HEX accepts an integer for length - the resulting string will be double this length.
 
 ## Config File Format
 

--- a/json2envdir.go
+++ b/json2envdir.go
@@ -2,6 +2,8 @@ package json2envdir
 
 import (
 	"bytes"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -27,6 +29,13 @@ type Funcs struct {
 func (f Funcs) UUID() string {
 	u := uuid.NewV4()
 	return u.String()
+}
+
+// Hex allows templates to generate a hex of a specific length
+func (f Funcs) Hex(length int) string {
+	randomBytes := make([]byte, length)
+	rand.Read(randomBytes)
+	return hex.EncodeToString(randomBytes)
 }
 
 // Process parses and populates the envdirs specified in the config if matching

--- a/json2envdir.go
+++ b/json2envdir.go
@@ -32,7 +32,7 @@ func (f Funcs) UUID() string {
 }
 
 // Hex allows templates to generate a hex of a specific length
-func (f Funcs) Hex(length int) string {
+func (f Funcs) HEX(length int) string {
 	randomBytes := make([]byte, length)
 	rand.Read(randomBytes)
 	return hex.EncodeToString(randomBytes)

--- a/json2envdir_test.go
+++ b/json2envdir_test.go
@@ -61,7 +61,8 @@ func TestParse(t *testing.T) {
 		"name": "myapp",
 		"env": {
 			"MYVAR": "123",
-			"MYVAR_TMPL": "{{.UUID}}"
+			"MYVAR_TMPL": "{{.UUID}}",
+			"MYVAR_HEX": "{{.Hex 32}}"
 		}
 	}`)
 	if err != nil {
@@ -85,6 +86,14 @@ func TestParse(t *testing.T) {
 		t.Fatalf("Value of $MYVAR_TMPL in dir1 should contain a UUID")
 	}
 
+	hex1, err := ioutil.ReadFile(filepath.Join(dir1, "MYVAR_HEX"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hex1) != 64 {
+		t.Fatalf("Length of $MYVAR_HEX in dir1 should be 64, got: %d", len(hex1))
+	}
+
 	b, err = ioutil.ReadFile(filepath.Join(dir2, "MYVAR"))
 	if err != nil {
 		t.Fatal(err)
@@ -100,6 +109,14 @@ func TestParse(t *testing.T) {
 	uuid2, err := uuid.FromString(string(b))
 	if err != nil {
 		t.Fatalf("Value of $MYVAR_TMPL in dir2 should contain a UUID")
+	}
+
+	hex2, err := ioutil.ReadFile(filepath.Join(dir2, "MYVAR_HEX"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hex2) != 64 {
+		t.Fatalf("Length of $MYVAR_HEX in dir1 should be 64, got: %d", len(hex1))
 	}
 
 	if uuid1 != uuid2 {

--- a/json2envdir_test.go
+++ b/json2envdir_test.go
@@ -62,7 +62,7 @@ func TestParse(t *testing.T) {
 		"env": {
 			"MYVAR": "123",
 			"MYVAR_TMPL": "{{.UUID}}",
-			"MYVAR_HEX": "{{.Hex 32}}"
+			"MYVAR_HEX": "{{.HEX 32}}"
 		}
 	}`)
 	if err != nil {


### PR DESCRIPTION
Allow for hex generation as an alternative to uuid, to support a standard password format. DoD does this sort of password formatting now, and it might help in future lobster hunting.