### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: install dependencies
-        run: sudo apt-get update && apt-get install -y dh-golang git vim devscripts equivs build-essential golang-1.13-go golang-1.13-src golang-any golang-go golang-src
+        run: sudo apt-get update && sudo apt-get install -y dh-golang git vim devscripts equivs build-essential golang-1.13-go golang-1.13-src golang-any golang-go golang-src
       - name: Install packagecloud
         run: gem install package_cloud
       - name: build packagemk-build-deps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '*'
+  pull_request:
 jobs:
   build-ubuntu-packages:
     runs-on: [ubuntu-latest]
@@ -23,6 +24,9 @@ jobs:
           sudo mk-build-deps --install debian/control
           sudo debuild -i -us -uc -b
       - name: push package to packagecloud
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+          PACKAGECLOUD_REPO: ${{ secrets.PACKAGECLOUD_REPO }}
         run: |
           SUPPORTED_UBUNTU_VERSIONS="focal noble"
           for ubuntu_version in ${SUPPORTED_UBUNTU_VERSIONS}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - '*'
-  pull_request:
 jobs:
   build-ubuntu-packages:
     runs-on: [ubuntu-latest]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: install dependencies
-        run: sudo apt-get update && sudo apt-get install -y dh-golang git vim devscripts equivs build-essential golang-1.13-go golang-1.13-src golang-any golang-go golang-src
+        run: sudo apt-get update && sudo apt-get install -y dh-golang git vim devscripts equivs build-essential golang-go
       - name: Install packagecloud
         run: gem install package_cloud
       - name: build packagemk-build-deps

--- a/debian/rules
+++ b/debian/rules
@@ -5,3 +5,5 @@
 
 %:
 	dh $@ --builddirectory=_build --buildsystem=golang
+
+override_dh_dwz:


### PR DESCRIPTION
## Fix PackageCloud workflow 

This PR fixes the GitHub Actions workflow for building and pushing packages to PackageCloud.

### Changes Made

**Workflow Fixes:**
- Fixed missing `sudo` in apt-get install command
- Updated Go package dependencies for Ubuntu Noble compatibility (removed obsolete golang-1.13 packages)
- Added `override_dh_dwz:` to disable dwz compression that fails with Go binaries
- Added proper environment variables for PackageCloud authentication using repository secrets

### Testing
- Workflow was tested and successfully builds packages for both Ubuntu versions
- Ready to push future releases to the Noble repository

## Refs

- [W-20542359](https://gus.lightning.force.com/a07EE00002RAQfxYAH)